### PR TITLE
Add invited talks for 2024-2025

### DIFF
--- a/_talks/2024-08-01-invited-sails.md
+++ b/_talks/2024-08-01-invited-sails.md
@@ -1,0 +1,11 @@
+---
+title: "XAI in Industry"
+collection: talks
+type: "Invited talk"
+permalink: /talks/2024-08-01-invited-sails
+venue: "SAILS Lunch Time Seminar"
+date: 2024-08-01
+location: "Online"
+---
+
+Invited talk on applications of explainable AI in industry at the SAILS Lunch Time Seminar.

--- a/_talks/2024-09-01-invited-microsoft-nl.md
+++ b/_talks/2024-09-01-invited-microsoft-nl.md
@@ -1,0 +1,11 @@
+---
+title: "XAI for Predictive Maintenance"
+collection: talks
+type: "Invited talk"
+permalink: /talks/2024-09-01-invited-microsoft-nl
+venue: "Microsoft Netherlands"
+date: 2024-09-01
+location: "Schiphol, The Netherlands"
+---
+
+Invited talk on explainable AI for predictive maintenance at Microsoft Netherlands.

--- a/_talks/2024-10-10-invited-vzi-healthtech.md
+++ b/_talks/2024-10-10-invited-vzi-healthtech.md
@@ -1,0 +1,11 @@
+---
+title: "XAI for Healthcare"
+collection: talks
+type: "Invited talk"
+permalink: /talks/2024-10-10-invited-vzi-healthtech
+venue: "VZI HealthTech 2024"
+date: 2024-10-10
+location: "Utrecht, The Netherlands"
+---
+
+Invited talk on explainable AI for healthcare at VZI HealthTech 2024.

--- a/_talks/2024-10-25-invited-alice-eve.md
+++ b/_talks/2024-10-25-invited-alice-eve.md
@@ -1,0 +1,11 @@
+---
+title: "Explainable AI"
+collection: talks
+type: "Invited talk"
+permalink: /talks/2024-10-25-invited-alice-eve
+venue: "Alice and Eve 2024"
+date: 2024-10-25
+location: "Leiden, The Netherlands"
+---
+
+Invited talk on explainable AI at Alice and Eve 2024.

--- a/_talks/2025-01-21-invited-xai-nl.md
+++ b/_talks/2025-01-21-invited-xai-nl.md
@@ -1,0 +1,11 @@
+---
+title: "Evaluating XAI"
+collection: talks
+type: "Invited talk"
+permalink: /talks/2025-01-21-invited-xai-nl
+venue: "XAI-NL meetup"
+date: 2025-01-21
+location: "Maastricht, The Netherlands"
+---
+
+Invited talk on evaluating explainable AI at the XAI-NL meetup.

--- a/_talks/2025-02-20-invited-atoniic.md
+++ b/_talks/2025-02-20-invited-atoniic.md
@@ -1,0 +1,11 @@
+---
+title: "LLaMEA for Automated Algorithm Design"
+collection: talks
+type: "Invited talk"
+permalink: /talks/2025-02-20-invited-atoniic
+venue: "AToNIIC lecture series"
+date: 2025-02-20
+location: "Online"
+---
+
+Invited talk for the AToNIIC lecture series: [https://altzanetos.com/atoniic/llamea-llm-ea-for-automatically-generating-metaheuristics/](https://altzanetos.com/atoniic/llamea-llm-ea-for-automatically-generating-metaheuristics/) (February 20, 2025, 15:00 CET).

--- a/_talks/2025-03-01-invited-tudelft.md
+++ b/_talks/2025-03-01-invited-tudelft.md
@@ -1,0 +1,11 @@
+---
+title: "XAI for Time Series"
+collection: talks
+type: "Invited talk"
+permalink: /talks/2025-03-01-invited-tudelft
+venue: "TU Delft"
+date: 2025-03-01
+location: "Delft, The Netherlands"
+---
+
+Invited talk on explainable AI for time series at TU Delft.

--- a/_talks/2025-06-10-invited-automl-summer-school.md
+++ b/_talks/2025-06-10-invited-automl-summer-school.md
@@ -1,0 +1,11 @@
+---
+title: "Automated Algorithm Design"
+collection: talks
+type: "Invited talk"
+permalink: /talks/2025-06-10-invited-automl-summer-school
+venue: "AutoML summer school"
+date: 2025-06-10
+location: "Tübingen, Germany"
+---
+
+Invited talk for the AutoML summer school in Tübingen, Germany (June 10–13, 2025).

--- a/_talks/2025-07-31-invited-automl-seminar.md
+++ b/_talks/2025-07-31-invited-automl-seminar.md
@@ -1,0 +1,24 @@
+---
+title: "Automated Algorithm Design"
+collection: talks
+type: "Invited talk"
+permalink: /talks/2025-07-31-invited-automl-seminar
+venue: "AutoML Seminar Series"
+date: 2025-07-31
+location: "Online"
+---
+
+Invited talk for the AutoML Seminar Series.
+
+**Title:** LLaMEA-BO: A Large Language Model Evolutionary Algorithm for Automatically Generating Bayesian Optimization Algorithms
+
+**Speakers:**
+- Elena Raponi: <https://www.universiteitleiden.nl/en/>
+- Niki van Stein: <https://www.universiteitleiden.nl/en/>
+
+**Papers:**
+- LLaMEA-BO: <https://arxiv.org/abs/2505.21034>
+- LLaMEA: <https://ieeexplore.ieee.org/abstract/>
+
+**Abstract:**
+Large Language Models (LLMs) are rapidly becoming creative co-pilots for AI, Optimization and AutoML, moving beyond tuning to generating and evolving entire algorithms on demand. This talk introduces LLaMEA, an evolutionary computation framework that uses LLMs to iteratively mutate and improve full codebases, generating competitive optimizers across continuous, combinatorial, and hyperparameter spaces. We specifically focus on its application to Bayesian Optimization (LLaMEA-BO), showing how LLM-generated code, guided by adapted prompt engineering and mutation schedules, consistently discovers high-performing BO algorithms and scales well across dimensions and tasks. The talk also covers integration with AutoML toolchains, insights from the BLADE benchmarking suite, and offers practical takeaways with open-source code.

--- a/_talks/2025-11-25-invited-autolearn.md
+++ b/_talks/2025-11-25-invited-autolearn.md
@@ -1,0 +1,11 @@
+---
+title: "Explainable Automated Algorithm Design"
+collection: talks
+type: "Invited keynote"
+permalink: /talks/2025-11-25-invited-autolearn
+venue: "Auto-Learn SI workshop"
+date: 2025-11-25
+location: "Ljubljana, Slovenia"
+---
+
+Invited keynote for the Auto-Learn SI workshop focusing on explainable approaches to automated algorithm design.


### PR DESCRIPTION
## Summary
- add invited talk entries for 2024 engagements focusing on XAI topics
- add multiple 2025 invited talks including LLaMEA-BO abstract and AutoML-related events

## Testing
- not run (documentation changes only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925bcf148388321a1899137947c9229)